### PR TITLE
docs(readme): updated hugging face login CLI code.

### DIFF
--- a/assignment_1/README.md
+++ b/assignment_1/README.md
@@ -59,7 +59,7 @@ conda create -p /pscratch/sd/e/$USER/sysml python=3.10.12
 - `meta-llama/Llama-3.1-8B`
 2. Log in your account from command line
    ```bash
-   huggingface-cli login
+   hf auth login
    # Create token through the url and copy-paste
    ```
 #### Step 3: Download model and tokenizer


### PR DESCRIPTION
'huggingface-cli login' is deprecated, hence proposing a change to 'hf auth login' command.

I am taking SYSML this sem, just noticed this while setting up my environment.